### PR TITLE
index.js: fix when sourceFile is /dev/null on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,12 @@ function applyPatch(patchFile) {
     throw Error("Unable to find destination file in '" + patchFile + "'");
   }
 
-  var original = fs.readFileSync(sourceFile, "utf8");
+  var original;
+  if (sourceFile == '/dev/null' && process.platform == 'win32') {
+    original = '';
+  } else {
+    original = fs.readFileSync(sourceFile, "utf8");
+  }
   var patched = diff.applyPatch(original, patch);
 
   if (patched === false) {
@@ -32,7 +37,9 @@ function applyPatch(patchFile) {
     console.log("Applied '" + patchFile + "' to '" + sourceFile + "'");
   }
 
-  fs.writeFileSync(destinationFile, patched);
+  if (!(destinationFile != '/dev/null' || process.platform != 'win32')) {
+    fs.writeFileSync(destinationFile, patched);
+  }
 }
 
 module.exports.applyPatch = applyPatch;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "apply-patch": "./index.js"
   },
   "dependencies": {
-    "diff": "2.1.1"
+    "diff": "5.1.0"
   }
 }


### PR DESCRIPTION
On windows the /dev/null device is not existing, set original to the null string in that case.